### PR TITLE
Restore database retrieval option

### DIFF
--- a/Alarm_algo.py
+++ b/Alarm_algo.py
@@ -1,250 +1,137 @@
 #!/usr/bin/env python
-# coding: utf-8
+"""Utility script to merge trend and alarm data and mark failure periods."""
 
-# In[191]:
-
-
-#alle packages
+import os
+import configparser
+from datetime import datetime
 import pandas as pd
+import pyodbc
 
 
-# In[192]:
+def fetch_trend_db(config_path: str = "input_data.ini") -> pd.DataFrame:
+    """Fetch trend data from INSQL using settings in the given config file."""
+    cfg = configparser.ConfigParser()
+    cfg.read(config_path)
 
+    tags = cfg.get("QUERY", "tags").split(", ")
+    start = cfg.get("QUERY", "start_datetime")
+    end = cfg.get("QUERY", "end_datetime")
 
-# 1. Read the CSV, parsing the DateTime column as datetime64
-df = pd.read_csv(
-    'historian.db.F5.03.csv',
-    parse_dates=['DateTime']        # ← this ensures df['DateTime'] is datetime64[ns]
-)
+    mode = cfg.get("QUERY_SETTINGS", "ww_retrieval_mode", fallback="Cyclic")
+    res = cfg.getint("QUERY_SETTINGS", "ww_resolution", fallback=10000)
+    rule = cfg.get("QUERY_SETTINGS", "ww_quality_rule", fallback="Extended")
+    ver = cfg.get("QUERY_SETTINGS", "ww_version", fallback="Latest")
+    threshold = cfg.getint("QUERY_SETTINGS", "production_mode_threshold", fallback=5)
 
-# 2. Melt into long format
-trend = df.melt(
-    id_vars=['DateTime'],
-    var_name='asset',
-    value_name='valve_pos'
-)
+    conn = pyodbc.connect(
+        r"Driver={SQL Server};Server=IJMHISDBS03.EDIS.TATASTEEL.COM;Database=Runtime;Trusted_Connection=yes;"
+    )
+    cursor = conn.cursor()
 
-# 3. Clean up column names
-trend['asset'] = trend['asset'].str.replace(r'\.Status$', '', regex=True)
-
-# 4. Rename columns to match your desired output
-trend.rename(columns={
-    'DateTime': 'dt', 
-    'valve_pos': 'valve pos'
-}, inplace=True)
-
-# 5. (Optional) Display or save the result
-print(trend.head())
-# trend.to_csv('trend.csv', index=False)
-
-
-# In[193]:
-
-
-# assuming df is your big or small DataFrame
-trend['asset'] = trend['asset'].str[-3:].astype(int) - 20
-
-
-# In[194]:
-
-
-print(trend.sort_values(by = 'dt').head)
-
-
-# In[195]:
-
-
-def load_alarm_dataframe(filepath: str = 'alarm.viewer.F5.03.xlsx') -> pd.DataFrame:
-    """
-    Loads an Excel file of alarms, parses TagName into Tag and Alarm,
-    and returns a DataFrame with DateTime, Tag and Alarm columns.
-    """
-    # Read in the Excel file
-    df = pd.read_excel(filepath, engine='openpyxl')
-
-    
-    # Ensure DateTime is a datetime dtype
-    df['DateTime'] = pd.to_datetime(df['DateTime'])
-    
-    # Split TagName into three parts: prefix1, prefix2, and alarm name
-    parts = df['TagName'].str.split('.', n=2, expand=True)
-    
-    # Recombine first two parts for Tag and take the third part as Alarm
-    df['Tag']   = parts[0] + '.' + parts[1]
-    df['Alarm'] = parts[2]
-    
-    # Return only the columns you care about
-    return df[['DateTime','Tag','Alarm']]
-    
-
-# --- usage elsewhere in your code ---
-alarm_df = load_alarm_dataframe()   # now `alarm_df` holds your processed data
-
-alarm_df.rename(columns={'DateTime': 'dt'}, inplace=True)
-
-# in-place overwrite:
-alarm_df['Tag'] = (
-    alarm_df['Tag']
-      .str.extract(r'(\d{3})\.PV$')[0]  # grab the "001"… "012"
-      .astype(int)                      # turn "001"→1, … "012"→12
-)
-
-
-# You can reuse `alarm_df` anytime later:
-print(alarm_df)
-
-
-# In[198]:
-
-
-# --- 2) Extract base Tag and map to asset in alarm_df ---
-#   e.g. "313PT009.PV" → "313PT009" → maps to "313XV029"
-alarm_df['asset'] = (
-    alarm_df['Tag']
-)
-
-# --- 3) Normalize both DataFrames: dt → DateTime, parse, sort by asset & time ---
-def prep(df):
-    # drop any duplicate columns
-    df = df.loc[:, ~df.columns.duplicated()]
-    # rename 'dt' → 'DateTime'
-    if 'dt' in df.columns:
-        df = df.rename(columns={'dt':'DateTime'})
-    # ensure DateTime exists
-    if 'DateTime' not in df.columns:
-        raise KeyError(f"'DateTime' not found in {df.columns.tolist()}")
-    df['DateTime'] = pd.to_datetime(df['DateTime'])
-    return df
-
-trend    = prep(trend)
-alarm_df = prep(alarm_df)
-
-trend    = trend   .sort_values(['asset','DateTime']).reset_index(drop=True)
-alarm_df = alarm_df.sort_values(['asset','DateTime']).reset_index(drop=True)
-
-
-
-
-# In[209]:
-
-
-import pandas as pd
-
-# ensure DateTime is datetime, and asset_id is int in both tables
-for df in (trend, alarm_df):
-    df['DateTime'] = pd.to_datetime(df['DateTime'])
-    df['asset'] = df['asset'].astype(int)
-
-# helper to asof-merge one asset's worth of rows
-def asof_for_asset(asset, trend_grp):
-    # take only the alarm rows for this asset
-    alarms = alarm_df[alarm_df['asset'] == asset]
-    # both must be sorted by time for merge_asof
-    trend_grp = trend_grp.sort_values('DateTime')
-    alarms    = alarms.sort_values('DateTime')
-    # merge—the last alarm at or before each trend timestamp
-    return pd.merge_asof(
-        trend_grp,
-        alarms,
-        on='DateTime',
-        direction='backward',
-        suffixes=('','_alarm')
+    tags_str = ", ".join(f"[{tag}]" for tag in tags)
+    query = (
+        "SET QUOTED_IDENTIFIER OFF "
+        "SELECT * FROM OPENQUERY(INSQL, \"SELECT "
+        "DateTime = convert(nvarchar, DateTime, 21), "
+        f"{tags_str} "
+        "FROM WideHistory "
+        f"WHERE wwRetrievalMode = '{mode}' "
+        f" AND wwResolution = {res} "
+        f" AND wwQualityRule = '{rule}' "
+        f"AND wwVersion = '{ver}' "
+        f"AND DateTime >= '{start}' "
+        f"AND DateTime <= '{end}' "
+        f"AND [PlantInformation.ProductionMode] >= {threshold} \" )"
     )
 
-# apply per-asset and reassemble
-merged = (
-    trend
-      .groupby('asset', group_keys=False)
-      .apply(lambda grp: asof_for_asset(grp.name, grp))
-      .reset_index(drop=True)
-)
+    cursor.execute(query)
+    rows: list[pyodbc.Row] = []
+    while True:
+        chunk = cursor.fetchmany(1000)
+        if not chunk:
+            break
+        rows.extend(chunk)
+    cursor.close()
+
+    df = pd.DataFrame.from_records(rows, columns=["DateTime"] + tags)
+    df["DateTime"] = pd.to_datetime(df["DateTime"])
+    return df
 
 
-# In[210]:
+def load_trend(path: str = "historian.db.F5.03.csv", config_path: str | None = None) -> pd.DataFrame:
+    """Return melted trend data from CSV or database with normalized asset numbers."""
+    if config_path:
+        df = fetch_trend_db(config_path)
+    else:
+        df = pd.read_csv(path, parse_dates=["DateTime"])
+    trend = df.melt(id_vars=["DateTime"], var_name="asset", value_name="valve pos")
+    trend["asset"] = (
+        trend["asset"].str.replace(r"\.Status$", "", regex=True).str[-3:].astype(int) - 20
+    )
+    trend.rename(columns={"DateTime": "dt"}, inplace=True)
+    return trend.sort_values("dt").reset_index(drop=True)
 
 
-merged.count(
-)
+def load_alarm(path: str = "alarm.viewer.F5.03.xlsx") -> pd.DataFrame:
+    """Return alarm data with extracted asset numbers."""
+    df = pd.read_excel(path, engine="openpyxl")
+    df["DateTime"] = pd.to_datetime(df["DateTime"])
+    parts = df["TagName"].str.split(".", n=2, expand=True)
+    alarm = pd.DataFrame(
+        {
+            "DateTime": df["DateTime"],
+            "asset": parts[0] + "." + parts[1],
+            "Alarm": parts[2],
+        }
+    )
+    alarm["asset"] = alarm["asset"].str.extract(r"(\d{3})\.PV")[0].astype(int)
+    return alarm
 
 
-# In[ ]:
+def merge_data(trend: pd.DataFrame, alarm: pd.DataFrame) -> pd.DataFrame:
+    trend = trend.rename(columns={"dt": "DateTime"})
+    merged = pd.merge(trend, alarm, on=["DateTime", "asset"], how="left")
+    return merged
 
 
-merged = pd.merge(
-    trend,
-    alarm_df,
-    on=['DateTime','asset'],
-    how='left'          # ← keeps every row from big_df
-)
+def add_alarm_flags(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.sort_values("DateTime").reset_index(drop=True)
+    mask = df["Alarm"].notna() & df["Alarm"].str.strip().ne("")
+    df["alarm_time"] = df["DateTime"].where(mask).ffill()
+    df["alarm_flag"] = (
+        (df["DateTime"] - df["alarm_time"] <= pd.Timedelta(seconds=5))
+        .fillna(False)
+        .astype(int)
+    )
+    return df.drop(columns="alarm_time")
 
 
-# In[ ]:
+def mark_failures(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.sort_values(["asset", "DateTime"]).reset_index(drop=True)
+    failure_state = 0
+    periods = []
+    for flag, valve in zip(df["alarm_flag"], df["valve pos"]):
+        if not failure_state and flag == 1 and valve == 1:
+            failure_state = 1
+        elif failure_state and valve == 2:
+            failure_state = 0
+        periods.append(failure_state)
+    df["failure_period"] = periods
+    return df
 
 
-counts = merged.count()
-print(counts)
+def main(config_path: str | None = None) -> None:
+    trend = load_trend(config_path=config_path)
+    alarms = load_alarm()
+    merged = merge_data(trend, alarms)
+    merged = add_alarm_flags(merged)
+    merged = mark_failures(merged)
+    merged.to_csv("merged_with_alarm_flag.csv", index=False)
+    print(merged.count())
 
 
-# In[ ]:
+if __name__ == "__main__":
+    import sys
 
-
-# 1. Make sure your DataFrame is sorted by time
-merged = merged.sort_values('DateTime')
-
-# 2. Mark the times when an alarm appears
-#    We’ll create a helper column that is the timestamp when alarm is non-empty,
-#    and NaT everywhere else.
-merged['alarm_time'] = merged['DateTime'].where(merged['Alarm'].notna() & (merged['Alarm'].str.strip() != ''))
-
-# 3. Propagate (forward-fill) that timestamp to subsequent rows
-merged['alarm_time'] = merged['alarm_time'].ffill()
-
-# 4. Compute flag: 1 if current row is within 5 seconds of the last alarm_time
-merged['alarm_flag'] = (
-    (merged['DateTime'] - merged['alarm_time']) <= pd.Timedelta(seconds=5)
-).fillna(False).astype(int)
-
-
-
-# In[ ]:
-
-
-# 1. Make sure your rows are in chronological order
-merged = merged.sort_values(['asset','DateTime']).reset_index(drop=True)
-
-# 2. Prepare the output column and a little “state” variable
-merged['failure_period'] = 0
-in_failure = 0
-
-# 3. Walk through each row and update the state
-for i, row in merged.iterrows():
-    # if we’re not in a failure, check for the start condition
-    if in_failure == 0 and row['alarm_flag'] == 1 and row['valve pos'] == 1:
-        in_failure = 1
-    # if we are in a failure, check for the stop condition
-    elif in_failure == 1 and row['valve pos'] == 2:
-        in_failure = 0
-
-    # write the current state into the new column
-    merged.at[i, 'failure_period'] = in_failure
-
-
-# In[ ]:
-
-
-merged.info()
-
-
-# In[ ]:
-
-
-# save without the index column
-merged.to_csv('merged_with_alarm_flag.csv', index=False)
-
-
-# In[ ]:
-
-
-counts = merged.count()
-print(counts)
-
+    cfg = sys.argv[1] if len(sys.argv) > 1 else None
+    main(config_path=cfg)

--- a/input_data.ini
+++ b/input_data.ini
@@ -1,0 +1,14 @@
+[QUERY]
+tags = Tag1, Tag2
+start_datetime = 2024-01-01 00:00:00
+end_datetime = 2024-01-02 00:00:00
+
+[OUTPUT]
+csv_directory = .
+
+[QUERY_SETTINGS]
+ww_retrieval_mode = Cyclic
+ww_resolution = 10000
+ww_quality_rule = Extended
+ww_version = Latest
+production_mode_threshold = 5


### PR DESCRIPTION
## Summary
- reintroduce DB retrieval logic via `fetch_trend_db`
- support config-driven trend loading in `load_trend`
- allow optional config path for `main`
- add sample `input_data.ini`

## Testing
- `python -m py_compile Alarm_algo.py`

------
https://chatgpt.com/codex/tasks/task_e_68418d23974c8324a0f147103e929f22