### PR TITLE
Update datetime conversion in load_313pt0_alarms

### DIFF
--- a/alarm.py
+++ b/alarm.py
@@ -22,7 +22,8 @@ def load_313pt0_alarms(path: str = ALARM_FILE) -> pd.DataFrame:
     alarm = df[df["TagName"].str.contains("313PT0", na=False)].copy()
     alarm = alarm[alarm["MessageText"].str.contains(r"HiHi level|LoLo level", na=False, regex=True)]
     alarm = alarm[["DateTime", "TagName"]].copy()
-    alarm["DateTime"] = alarm["DateTime"].apply(robust_parse).dt.ceil("5S")
+    alarm["DateTime"] = alarm["DateTime"].apply(robust_parse)
+    alarm["DateTime"] = pd.to_datetime(alarm["DateTime"]).dt.ceil("5S")
     parts = alarm["TagName"].str.split(".", expand=True)
     alarm["asset"] = parts[0] + "." + parts[1]
     alarm["alarm"] = parts[2]


### PR DESCRIPTION
## Summary
- use `pd.to_datetime` after `robust_parse`
- keep return columns unchanged

## Testing
- `python -m py_compile alarm.py`

------
https://chatgpt.com/codex/tasks/task_e_6842aa7662248324901e22a37b7f3dfb