### PR TITLE
Add empty alarm check to load_313pt0_alarms

### DIFF
--- a/alarm.py
+++ b/alarm.py
@@ -22,6 +22,12 @@ def load_313pt0_alarms(path: str = ALARM_FILE) -> pd.DataFrame:
     alarm = df[df["TagName"].str.contains("313PT0", na=False)].copy()
     alarm = alarm[alarm["MessageText"].str.contains(r"HiHi level|LoLo level", na=False, regex=True)]
     alarm = alarm[["DateTime", "TagName"]].copy()
+    if alarm.empty:
+        return pd.DataFrame({
+            "DateTime": pd.Series(dtype="datetime64[ns]"),
+            "asset": pd.Series(dtype="int"),
+            "alarm": pd.Series(dtype="object"),
+        })
     alarm["DateTime"] = alarm["DateTime"].apply(robust_parse)
     alarm["DateTime"] = pd.to_datetime(alarm["DateTime"]).dt.ceil("5S")
     parts = alarm["TagName"].str.split(".", expand=True)


### PR DESCRIPTION
## Summary
- return an empty typed DataFrame when no 313PT0 alarms are found

## Testing
- `python -m py_compile alarm.py`

------
https://chatgpt.com/codex/tasks/task_e_6842af334e588324add6b629e0b193d4