### PR TITLE
Add GUI file selection for alarm

### DIFF
--- a/alarm.py
+++ b/alarm.py
@@ -4,8 +4,23 @@ import numpy as np
 import pandas as pd
 import pyodbc
 from dateutil import parser
+from tkinter import Tk, filedialog
 
-ALARM_FILE = "alarm.viewer.F4.09.xlsx"
+
+def select_alarm_file() -> str:
+    """Open a file chooser dialog and return the selected path."""
+    root = Tk()
+    root.withdraw()
+    root.wm_attributes("-topmost", 1)
+    file_path = filedialog.askopenfilename(
+        title="Select alarm Excel file",
+        filetypes=[("Excel files", "*.xlsx *.xls"), ("All files", "*.*")],
+    )
+    root.destroy()
+    return file_path
+
+
+ALARM_FILE = select_alarm_file()
 
 
 def robust_parse(value):


### PR DESCRIPTION
## Summary
- open a file chooser dialog at startup and use the selected path for `ALARM_FILE`

## Testing
- `python -m py_compile alarm.py`

------
https://chatgpt.com/codex/tasks/task_e_6842a79f3e148324a1bd552145297cdb