### PR TITLE
Fix date parsing for alarm timestamps

### DIFF
--- a/alarm.py
+++ b/alarm.py
@@ -33,7 +33,8 @@ def robust_parse(value):
     if isinstance(value, (int, float)):
         return pd.to_datetime("1899-12-30") + pd.to_timedelta(value, unit="D")
     try:
-        return parser.parse(str(value), dayfirst=True)
+        # Alarm exports use MM/DD/YY format, so disable day-first parsing
+        return parser.parse(str(value), dayfirst=False)
     except ValueError:
         return pd.NaT
 


### PR DESCRIPTION
## Summary
- parse alarm datetimes in US-style MM/DD/YY format

## Testing
- `python -m py_compile alarm.py`


------
https://chatgpt.com/codex/tasks/task_e_6842e06750988324b279d0ae0d095e17