### PR TITLE
Update README with alarm export note

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Both the notebook and script produce a merged CSV file with the computed alarm f
 ## Configuration
 
 `input_data.ini` specifies the historian tags and query parameters for database queries.
+Ensure that your alarm exports use the `MM/DD/YY HH:MM:SS` timestamp format or
+adjust the `robust_parse` function if your locale differs.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- clarify date format for alarm exports

## Testing
- `python -m py_compile alarm.py`


------
https://chatgpt.com/codex/tasks/task_e_6842e7b61e5c832483a07bcbc71ccdc0